### PR TITLE
make Choicy work better on iOS15 A12+ devices

### DIFF
--- a/BaseBin/launchdhook/src/jbserver/jbdomain_systemwide.c
+++ b/BaseBin/launchdhook/src/jbserver/jbdomain_systemwide.c
@@ -287,7 +287,7 @@ int systemwide_process_checkin(audit_token_t *processToken, char **rootPathOut, 
 	}
 
 	bool fullyDebugged = false;
-	if (is_app_path(procPath) || is_sub_path(JBROOT_PATH("/Applications"), procPath)) {
+	if (isRemovableBundlePath(procPath) || isSubPathOf(JBROOT_PATH("/Applications"), procPath)) {
 /*************************************** roothide specific *********************************/
 		
 		// This is an app, enable CS_DEBUGGED based on user preference

--- a/BaseBin/libjailbreak/src/jbserver.c
+++ b/BaseBin/libjailbreak/src/jbserver.c
@@ -7,6 +7,10 @@ int jbserver_received_xpc_message(struct jbserver_impl *server, xpc_object_t xms
 {
 	if (xpc_get_type(xmsg) != XPC_TYPE_DICTIONARY) return -1;
 
+/**********************************************/
+	roothide_handler_jbserver_msg(xmsg);
+/*********************************************/
+
 	if (!xpc_dictionary_get_value(xmsg, "jb-domain")) return -1;
 	if (!xpc_dictionary_get_value(xmsg, "action")) return -1;
 
@@ -20,14 +24,6 @@ int jbserver_received_xpc_message(struct jbserver_impl *server, xpc_object_t xms
 
 	audit_token_t clientToken = { 0 };
 	xpc_dictionary_get_audit_token(xmsg, &clientToken);
-
-
-/************************************/
-const char* desc = NULL;
-JBLogDebug("jbserver received xpc message from (%d) %s :\n%s", audit_token_to_pid(clientToken), proc_get_path(audit_token_to_pid(clientToken),NULL), (desc=xpc_copy_description(xmsg)));
-if(desc) free((void*)desc);
-/************************************/
-
 
 	if (domain->permissionHandler) {
 		if (!domain->permissionHandler(clientToken)) return -2;

--- a/BaseBin/libjailbreak/src/roothider/blacklist.m
+++ b/BaseBin/libjailbreak/src/roothider/blacklist.m
@@ -10,13 +10,13 @@
 NSString *getAppBundlePathFromSpawnPath(const char *path) {
     if (!path) return nil;
 
-    char rp[PATH_MAX];
-    if (!realpath(path, rp)) return nil;
+    char abspath[PATH_MAX];
+    if (!realpath(path, abspath)) return nil;
 
-    if (strncmp(rp, APP_PATH_PREFIX, sizeof(APP_PATH_PREFIX) - 1) != 0)
+    if (strncmp(abspath, APP_PATH_PREFIX, sizeof(APP_PATH_PREFIX) - 1) != 0)
         return nil;
 
-    char *p1 = rp + sizeof(APP_PATH_PREFIX) - 1;
+    char *p1 = abspath + sizeof(APP_PATH_PREFIX) - 1;
     char *p2 = strchr(p1, '/');
     if (!p2) return nil;
 
@@ -29,7 +29,7 @@ NSString *getAppBundlePathFromSpawnPath(const char *path) {
 
     p[sizeof(".app/") - 1] = '\0';
 
-    return [NSString stringWithUTF8String:rp];
+    return [NSString stringWithUTF8String:abspath];
 }
 
 // get main bundle identifier of app for (PlugIns's) executable path
@@ -48,9 +48,15 @@ NSString *getAppIdentifierFromPath(const char *path) {
     return identifier;
 }
 
+NSArray* builtinApps = @[
+    @"com.opa334.Dopamine-roothide",
+];
+
 bool isBlacklistedApp(const char* identifier)
 {
     if(!identifier) return false;
+
+    if([builtinApps containsObject:@(identifier)]) return false;
 
     NSString* configFilePath = JBROOT_PATH(@"/var/mobile/Library/RootHide/RootHideConfig.plist");
     NSDictionary* roothideConfig = [NSDictionary dictionaryWithContentsOfFile:configFilePath];

--- a/BaseBin/libjailbreak/src/roothider/common.h
+++ b/BaseBin/libjailbreak/src/roothider/common.h
@@ -1,6 +1,7 @@
 #include <spawn.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <xpc/xpc.h>
 
 extern bool launchdhookFirstLoad;
 
@@ -26,14 +27,14 @@ bool isBlacklistedPid(pid_t pid);
 pid_t* allocBlacklistProcessId();
 void commitBlacklistProcessId(pid_t* pidp);
 
-bool is_app_path(const char* path);
-bool is_sub_path(const char* parent, const char* child);
-bool is_same_file(const char* path1, const char* path2);
+bool isRemovableBundlePath(const char* path);
+bool isSubPathOf(const char* parent, const char* child);
 
 bool string_has_prefix(const char *str, const char* prefix);
 bool string_has_suffix(const char* str, const char* suffix);
 
-bool hasTrollstoreLiteMarker(const char* exepath);
+bool hasTrollstoreMarker(const char* path);
+bool hasTrollstoreLiteMarker(const char* path);
 
 void ensure_jbroot_symlink(const char* filepath);
 
@@ -59,3 +60,4 @@ void hideDeveloperMode();
 void exec_set_patch(bool enabled);
 int exec_cmd_roothide_spawn(pid_t* pidp, const char* path, const posix_spawn_file_actions_t *fap, const posix_spawnattr_t *attrp, char *const argv[], char *const envp[]);
 
+void roothide_handler_jbserver_msg(xpc_object_t xmsg);

--- a/BaseBin/libjailbreak/src/roothider/recdhash.m
+++ b/BaseBin/libjailbreak/src/roothider/recdhash.m
@@ -194,7 +194,7 @@ int ensure_randomized_cdhash_for_slice(const char* inputPath, uint64_t offset, v
 			break;
 		}
 
-		if(is_app_path(inputPath))
+		if(isRemovableBundlePath(inputPath))
 		{
 			if(!hasTrollstoreLiteMarker(inputPath)) {
 				// ignore adhoc signed apps(removable system apps or other stuffs) which is not installed via tslite

--- a/BaseBin/roothidehooks/common.h
+++ b/BaseBin/roothidehooks/common.h
@@ -6,7 +6,7 @@
 #include <libjailbreak/roothider.h>
 #include <libjailbreak/codesign.h>
 
-bool isJailbreakPath(const char* path);
+bool isJailbreakBundlePath(const char* path);
 
 //These apps may be signed with a (fake) certificate
 #define SENSITIVE_APP_LIST   @[ \

--- a/BaseBin/systemhook/src/common.c
+++ b/BaseBin/systemhook/src/common.c
@@ -136,28 +136,20 @@ static int spawn_exec_hook_common(const char *path,
 			break;
 		}
 
-
-/*********** roothide specific ************/
-struct statfs fs = {0};
-bool isAppPath = is_app_path(path);
-bool nonJailbreakPath = statfs(path, &fs)==0 && strcmp(fs.f_mntonname, "/private/var") != 0;
-/*********************************** roothide specific *************************************/
-
-
 		// Check if we can find a _SafeMode or _MSSafeMode variable
 		// In this case we do not want to inject anything
 		const char *safeModeValue = envbuf_getenv((const char **)envp, "_SafeMode");
 		const char *msSafeModeValue = envbuf_getenv((const char **)envp, "_MSSafeMode");
 		if (safeModeValue) {
 			if (!strcmp(safeModeValue, "1")) {
-				if(nonJailbreakPath||isAppPath) shouldInsertJBEnv = false;
+				if(!allowInjectWithSafeMode(path)) shouldInsertJBEnv = false;
 				hasSafeModeVariable = true;
 				break;
 			}
 		}
 		if (msSafeModeValue) {
 			if (!strcmp(msSafeModeValue, "1")) {
-				if(nonJailbreakPath||isAppPath) shouldInsertJBEnv = false;
+				if(!allowInjectWithSafeMode(path)) shouldInsertJBEnv = false;
 				hasSafeModeVariable = true;
 				break;
 			}

--- a/BaseBin/systemhook/src/roothider.h
+++ b/BaseBin/systemhook/src/roothider.h
@@ -27,7 +27,12 @@ void abort_with_reason(uint32_t reason_namespace, uint64_t reason_code, const ch
 #define PROCLOG(progname, ...) do { const char* name=getprogname(); if(name && strcmp(name, progname)==0) {SYSLOG(__VA_ARGS__);} } while(0)
 #define PROCASSERT(progname, e) do { const char* name=getprogname(); if(name && strcmp(name, progname)==0) {ASSERT(e);} } while(0)
 
-bool is_app_path(const char* path);
+pid_t __getppid();
+
+bool hasTrollstoreMarker(const char* path);
+bool isRemovableBundlePath(const char* path);
+bool allowInjectWithSafeMode(const char* path);
+
 void roothide_init();
 void roothide_init_with_checkin(const char* rootdir);
 void roothide_init_with_executable(const char* executable);

--- a/BaseBin/systemhook/src/roothider_common.c
+++ b/BaseBin/systemhook/src/roothider_common.c
@@ -1,10 +1,121 @@
 #include <stdio.h>
 #include <unistd.h>
+#include <libproc.h>
+#include <sys/mount.h>
 #include <sys/sysctl.h>
 #include <sys/syscall.h>
+#include <sys/proc_info.h>
 #include <dispatch/dispatch.h>
 
 #include "roothider.h"
+
+pid_t __getppid()
+{
+	int32_t opt[4] = {
+		CTL_KERN,
+		KERN_PROC,
+		KERN_PROC_PID,
+		getpid(),
+	};
+	struct kinfo_proc info={0};
+	size_t len = sizeof(struct kinfo_proc);
+	if(sysctl(opt, 4, &info, &len, NULL, 0) == 0) {
+		if((info.kp_proc.p_flag & P_TRACED) != 0) {
+			return info.kp_proc.p_oppid;
+		}
+	}
+
+    struct proc_bsdinfo procInfo;
+	//some process may be killed by sandbox if call systme getppid() so try this first
+	if (proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &procInfo, sizeof(procInfo)) == sizeof(procInfo)) {
+		return procInfo.pbi_ppid;
+	}
+
+	return getppid();
+}
+
+#define APP_PATH_PREFIX "/private/var/containers/Bundle/Application/"
+char* getAppUUIDPath(const char* path)
+{
+    if(!path) return NULL;
+
+    char abspath[PATH_MAX];
+    if(!realpath(path, abspath)) return NULL;
+
+    if(strncmp(abspath, APP_PATH_PREFIX, sizeof(APP_PATH_PREFIX)-1) != 0)
+        return NULL;
+
+    char* p1 = abspath + sizeof(APP_PATH_PREFIX)-1;
+    char* p2 = strchr(p1, '/');
+    if(!p2) return NULL;
+
+    //is normal app or jailbroken app/daemon?
+    if((p2 - p1) != (sizeof("xxxxxxxx-xxxx-xxxx-yxxx-xxxxxxxxxxxx")-1))
+        return NULL;
+	
+	*p2 = '\0';
+
+	return strdup(abspath);
+}
+
+bool isRemovableBundlePath(const char* path)
+{
+    const char* uuidpath = getAppUUIDPath(path);
+	if(!uuidpath) return false;
+	free((void*)uuidpath);
+	return true;
+}
+
+bool hasTrollstoreMarker(const char* path)
+{
+    char* uuidpath = getAppUUIDPath(path);
+	if(!uuidpath) return false;
+
+	char* markerpath=NULL;
+	asprintf(&markerpath, "%s/_TrollStore", uuidpath);
+
+	int ret = access(markerpath, F_OK);
+    if(ret != 0) {
+        free((void*)markerpath); markerpath = NULL;
+        asprintf(&markerpath, "%s/_TrollStoreLite", uuidpath);
+        ret = access(markerpath, F_OK);
+    }
+
+    free((void*)markerpath);
+	free((void*)uuidpath);
+
+	return ret==0;
+}
+
+/* the only reason this function exists is to allow Choicy
+	 to block systemhook injection for both stock daemons and normal apps (but not for their child processes) */
+bool allowInjectWithSafeMode(const char* path)
+{
+	if(getpid() != 1) {
+		return true;
+	}
+
+	if(isRemovableBundlePath(path))
+	{
+		if(hasTrollstoreMarker(path)) {
+			//always inject into trollstored apps unless we blacklist it in roothide manager
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	struct statfs fs = {0};
+	if(statfs(path, &fs) == 0) {
+		if(strcmp(fs.f_mntonname, "/") == 0) {
+			// disallow injecting into system process if Choicy blocked it
+			return false;
+		}
+	}
+
+	return true;
+}
+
 
 int __sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, const void *newp, size_t newlen);
 int syscall__sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, const void *newp, size_t newlen) {


### PR DESCRIPTION
- Choicy can now better hide jailbreak on iOS15 A12+ devices

- Time Bomb 2 will not cause spin lock even if it is blocked by Choicy

- fix the remove jailbreak button not working on non-jailbroken state

- fix Xcode not working after rebooting userspace on iOS15

- re-implemented more general hiding jailbreak url schemes